### PR TITLE
Fix --complete release log

### DIFF
--- a/lib/changelog.rb
+++ b/lib/changelog.rb
@@ -89,7 +89,7 @@ class Changelog
     str = ""
 
     str << tag_info { |t| t }
-    str << commit_info { |ci| " (_#{ci}_)\n" }
+    str << commit_info { |ci| ci.empty? ? "" : "(_#{ci}_)\n"  }
     str << sections(
       changes,
       -> (header) { "*#{header.capitalize}*\n" },

--- a/lib/changelog.rb
+++ b/lib/changelog.rb
@@ -27,9 +27,9 @@ class Changelog
   # Display tag information about the tag that the changelog is created for
   def tag_info
     if @tag_to && @tag_to.name
-      yield("#{@tag_to.name}")
+      yield("#{@tag_to.name}\n")
     else
-      yield("Unreleased")
+      yield("Unreleased\n")
     end
   end
 
@@ -104,7 +104,7 @@ class Changelog
     str = ""
 
     str << tag_info { |t| "## #{t}" }
-    str << commit_info { |ci| " (_#{ci}_)" }
+    str << commit_info { |ci| ci.empty? ? "" : "(_#{ci}_)\n" }
     str << sections(
       changes,
       -> (header) { "\n*#{header.capitalize}*\n" },

--- a/lib/changelog_helpers.rb
+++ b/lib/changelog_helpers.rb
@@ -106,12 +106,12 @@ end
 
 # Searches the commit log messages of all commits between `commit_from` and `commit_to` for changes
 def searchGitLog(repo, commit_from, commit_to, scope, logger)
-  logger.info("Traversing git tree from commit #{commit_from.oid} to commit #{commit_to && commit_to.oid}")
+  # logger.info("Traversing git tree from commit #{commit_from.oid} to commit #{commit_to && commit_to ? commit_to.oid : '(no oid)'}")
 
   # Initialize a walker that walks through the commits from the <from-commit> to the <to-commit>
   walker = Rugged::Walker.new(repo)
   walker.sorting(Rugged::SORT_DATE)
-  walker.push(commit_to)
+  walker.push(commit_to) unless commit_to == nil
   commit_from.parents.each do |parent|
     walker.hide(parent)
   end unless commit_from == nil

--- a/lib/git-releaselog.rb
+++ b/lib/git-releaselog.rb
@@ -52,27 +52,29 @@ class Releaselog
       if index == 0
           # First Interval: Generate from start of Repo to the first Tag
           changes = searchGitLog(repo, nil, tag.target, scope, logger)
-          changeLogs += [Changelog.new(changes, tag, nil, nil, nil)]
+          changeLogs += [Changelog.new(changes, nil, tag, nil, nil)]
 
-          logger.info("First Tag: #{tag.name}: #{changes.count} changes")
           logger.info("Parsing from start of the repo to #{tag.target.oid}")
+          logger.info("First Tag: #{tag.name}: #{changes.count} changes")
         else
           # Normal interval: Generate from one Tag to the next Tag
           previousTag = sorted_tags[index-1]
           changes = searchGitLog(repo, previousTag.target, tag.target, scope, logger)
-          changeLogs += [Changelog.new(changes, tag, previousTag, nil, nil)]
+          changeLogs += [Changelog.new(changes, previousTag, tag, nil, nil)]
 
-          logger.info("Tag #{previousTag.name} to #{tag.name}: #{changes.count} changes")
           logger.info("Parsing from #{tag.target.oid} to #{previousTag.target.oid}")
+          logger.info("Tag #{previousTag.name} to #{tag.name}: #{changes.count} changes")
         end
       end
 
       if sorted_tags.count > 0
         lastTag = sorted_tags.last
         # Last Interval: Generate from last Tag to HEAD
-        changes = searchGitLog(repo, repo.head.target, lastTag.target, scope, logger)
+        changes = searchGitLog(repo, lastTag.target, repo.head.target, scope, logger)
+        changeLogs += [Changelog.new(changes, lastTag, nil, nil, nil)]
+
+        logger.info("Parsing from #{lastTag.target.oid} to HEAD")
         logger.info("Tag #{lastTag.name} to HEAD: #{changes.count} changes")
-        changeLogs += [Changelog.new(changes, nil, lastTag, nil, nil)]
       end
 
       # Print the changelog

--- a/lib/git-releaselog.rb
+++ b/lib/git-releaselog.rb
@@ -47,17 +47,23 @@ class Releaselog
     sorted_tags = repo.tags.sort { |t1, t2| t1.target.time <=> t2.target.time }
     changeLogs = []
     sorted_tags.each_with_index do |tag, index|
+      logger.error("Tag #{tag.name} with date #{tag.target.time}")
+
       if index == 0
           # First Interval: Generate from start of Repo to the first Tag
-          changes = searchGitLog(repo, tag.target, repo.head.target, scope, logger)
-          logger.info("First Tag: #{tag.name}: #{changes.count} changes")
+          changes = searchGitLog(repo, nil, tag.target, scope, logger)
           changeLogs += [Changelog.new(changes, tag, nil, nil, nil)]
+
+          logger.info("First Tag: #{tag.name}: #{changes.count} changes")
+          logger.info("Parsing from start of the repo to #{tag.target.oid}")
         else
           # Normal interval: Generate from one Tag to the next Tag
           previousTag = sorted_tags[index-1]
-          changes = searchGitLog(repo, tag.target, previousTag.target, scope, logger)
-          logger.info("Tag #{previousTag.name} to #{tag.name}: #{changes.count} changes")
+          changes = searchGitLog(repo, previousTag.target, tag.target, scope, logger)
           changeLogs += [Changelog.new(changes, tag, previousTag, nil, nil)]
+
+          logger.info("Tag #{previousTag.name} to #{tag.name}: #{changes.count} changes")
+          logger.info("Parsing from #{tag.target.oid} to #{previousTag.target.oid}")
         end
       end
 

--- a/lib/git-releaselog.rb
+++ b/lib/git-releaselog.rb
@@ -73,7 +73,7 @@ class Releaselog
       if format == "md"
         changeLogs.reverse.map { |log| "#{log.to_md}\n" }
       elsif format == "slack"
-        changeLogs.reduce("") { |log, version| log + "1) #{version.to_slack}\n" }
+        changeLogs.reduce("") { |log, version| log + "#{version.to_slack}\n" }
       else
         logger.error("Unknown Format: `#{format}`")
       end


### PR DESCRIPTION
After changing the parameter order of tags (from/to) to the logical order, the `--complete` option did not work properly anymore. 

* fix: `--complete` option now generates a correct release log again