### PR TITLE
gui(output): markdown change section markup fixed

### DIFF
--- a/lib/git-releaselog/changelog.rb
+++ b/lib/git-releaselog/changelog.rb
@@ -108,7 +108,7 @@ module Releaselog
       str << commit_info { |ci| ci.empty? ? "" : "(_#{ci}_)\n" }
       str << sections(
         changes,
-        -> (header) { "\n*#{header.capitalize}*\n" },
+        -> (header) { "\n#####{header.capitalize}\n" },
         -> (field, _index) { "* #{field}\n" }
       )
 


### PR DESCRIPTION
The markup for a change section for markdown output was broken (likely a copy&paste error from #7)

* gui: Markdown output for change-sections now as sub-sub-sub-headline instead of italic