### PR TITLE
fix(tagInfo): tag info now correctly displays "Unreleased" again

### DIFF
--- a/lib/git-releaselog.rb
+++ b/lib/git-releaselog.rb
@@ -99,7 +99,7 @@ module Releaselog
 
         changes = searchGitLog(repo, commit_from, commit_to, scope, logger)
         # Create the changelog
-        log = Changelog.new(changes, from_ref, to_ref || latest_tag, commit_from, commit_to)
+        log = Changelog.new(changes, from_ref, to_ref, commit_from, commit_to)
 
         # Print the changelog
         case format


### PR DESCRIPTION
* fix: When there is no `to_tag`, the release log now correctly displays "Unreleased" again instead of the latest tag name