### PR TITLE
fix(options): check if a ref is nil before calling `strip` on it

### DIFF
--- a/lib/git-releaselog.rb
+++ b/lib/git-releaselog.rb
@@ -8,8 +8,8 @@ module Releaselog
   class Releaselog
     def self.generate_releaselog(options = {})
     repo_path = options.fetch(:repo_path, '.')
-    from_ref_name = options.fetch(:from_ref, nil).strip
-    to_ref_name = options.fetch(:to_ref, nil).strip
+    from_ref_name = options.fetch(:from_ref, nil).strip if options.fetch(:from_ref, nil)
+    to_ref_name = options.fetch(:to_ref, nil).strip if options.fetch(:to_ref, nil)
     scope = options.fetch(:scope, nil)
     format = options.fetch(:format, 'slack')
     generate_complete = options.fetch(:generate_complete, false)


### PR DESCRIPTION
This fixes #20 

Its not the most elegant way to do it, but it does the Job.

* fix: Providing no (or only one) ref does not crash the script anymore